### PR TITLE
Correcciones Recipe.jsx

### DIFF
--- a/The Food Venue/imports/ui/Recipe.jsx
+++ b/The Food Venue/imports/ui/Recipe.jsx
@@ -1,12 +1,9 @@
 import React, { Component, PropTypes } from 'react';
 import { Meteor } from 'meteor/meteor';
-import classnames from 'classnames';
 
-// Task component - represents a single todo item
-export default class Recipe extends Component {
+class Recipe extends Component {
   constructor(props) {
     super(props);
-
     this.goRecipe = this.goRecipe.bind(this);
   }
   goRecipe(idR) {
@@ -46,3 +43,6 @@ Recipe.propTypes = {
   num: React.PropTypes.number.isRequired,
   seeRecipe: PropTypes.func.isRequired,
 };
+
+// srojas19: Exportar clase al final para que reconozca que propTypes debe recibir.
+export default Recipe;


### PR DESCRIPTION
Eliminar import de classnames porque no se usa.
Exportar clase al final para reconocer los propTypes que debe recibir.